### PR TITLE
Fixes bundle ID retrieval for provisioning profiles

### DIFF
--- a/AppStoreConnectClient/AppStoreConnectClient.csproj
+++ b/AppStoreConnectClient/AppStoreConnectClient.csproj
@@ -8,7 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JWT" Version="10.1.1" />
+    <PackageReference Include="JWT" Version="11.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AppStoreConnectClient/BaseModels/IndividualResponse.cs
+++ b/AppStoreConnectClient/BaseModels/IndividualResponse.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+
+namespace AppleAppStoreConnect;
+
+public class IndividualResponse<TItem, TAttributes> : Response where TItem : Item<TAttributes>, new()
+{
+    public IndividualResponse() : base() { }
+
+    [JsonPropertyName("data")]
+    public TItem Data { get; set; } = new();
+}

--- a/AppStoreConnectClient/Client.Profiles.cs
+++ b/AppStoreConnectClient/Client.Profiles.cs
@@ -19,6 +19,13 @@ partial class AppStoreConnectClient
 		}
 	}
 
+	public async Task<BundleIdIndividualResponse> GetRelatedBundleIdAsync(string profileId, CancellationToken cancellationToken = default)
+	{
+		var qs = new QueryStringBuilder();
+		return await RequestAsync<BundleIdIndividualResponse>($"{PROFILES_TYPE}/{profileId}/bundleId", cancellationToken).ConfigureAwait(false)
+			?? new BundleIdIndividualResponse();
+	}
+	
 	public async Task<ProfileResponse> ListProfilesAsync(
 		string[]? filterId = null,
 		string[]? filterName = null,

--- a/AppStoreConnectClient/Client.cs
+++ b/AppStoreConnectClient/Client.cs
@@ -16,8 +16,26 @@ public partial class AppStoreConnectClient
 	public readonly AppStoreConnectConfiguration Configuration;
 
 
-	HttpClient http = new HttpClient();
+	HttpClient http = new HttpClient(new MetaDataHandler(
+#if DEBUG
+		true
+#else
+		false
+#endif
+		));
 
+	Task<T?> RequestAsync<T>(string path, CancellationToken cancellationToken = default)
+	{
+		var token = Configuration.AccessToken;
+
+		http.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+
+		return http.GetFromJsonAsync<T>(
+			UrlBase.TrimEnd('/') + $"/{path}",
+			JsonSerializerOptions,
+			cancellationToken);
+	}
+	
 	Task<T?> RequestAsync<T>(string path, QueryStringBuilder queryString, CancellationToken cancellationToken = default)
 	{
 		var token = Configuration.AccessToken;

--- a/AppStoreConnectClient/MetaDataDelegateHandler.cs
+++ b/AppStoreConnectClient/MetaDataDelegateHandler.cs
@@ -1,0 +1,53 @@
+using Serilog;
+
+namespace AppleAppStoreConnect;
+
+public class MetaDataHandler(bool shouldLogHttpRequests) : DelegatingHandler(new HttpClientHandler())
+{
+    private static readonly ILogger Logger = Log.ForContext<MetaDataHandler>();
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        if (shouldLogHttpRequests)
+        {
+            Logger.Information($">> {request.Method} REQUEST TO: {request.RequestUri}");
+
+            if (request.Headers.Any())
+            {
+                Logger.Information($">> HEADERS START");
+            }
+
+            foreach (var header in request.Headers)
+            {
+                Logger.Information($">> {header.Key.ToUpper()}      : {header.Value?.FirstOrDefault()}");
+            }
+
+            if (request.Headers.Any())
+            {
+                Logger.Information($">> HEADERS END");
+            }
+
+
+            if (request.Content != null)
+            {
+                Logger.Information($">> CONTENT   : {request.Content.ReadAsStringAsync(cancellationToken).Result}");
+            }
+        }
+
+        var response = await base.SendAsync(request, cancellationToken);
+
+        if (shouldLogHttpRequests)
+        {
+            Logger.Information($">> RESPONSE TO: {request.RequestUri}");
+
+            if (response.Content != null)
+            {
+                Logger.Information(
+                    $">> CONTENT   : {response.Content.ReadAsStringAsync(cancellationToken).Result}");
+            }
+        }
+
+
+        return response;
+    }
+}

--- a/AppStoreConnectClient/Models/BundleId.cs
+++ b/AppStoreConnectClient/Models/BundleId.cs
@@ -50,6 +50,15 @@ public class BundleId : Item<BundleIdAttributes>
 		=> Relationships["profiles"];
 }
 
+public class BundleIdIndividualResponse : IndividualResponse<BundleId, BundleIdAttributes>
+{
+	public BundleIdIndividualResponse() { }
+
+	[JsonIgnore]
+	public IEnumerable<Profile> IncludedProfiles
+		=> GetIncluded<Profile>();
+}
+
 public class BundleIdResponse : ListResponse<BundleId, BundleIdAttributes>
 {
 	public BundleIdResponse() { }

--- a/AppleDev.Test/AppleDev.Test.csproj
+++ b/AppleDev.Test/AppleDev.Test.csproj
@@ -10,13 +10,13 @@
 
     <ItemGroup>
 		<PackageReference Include="AppStoreConnect.Net" Version="0.1.1" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-        <PackageReference Include="xunit" Version="2.7.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.1">
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/AppleDev.Tool/AppleDev.Tool.csproj
+++ b/AppleDev.Tool/AppleDev.Tool.csproj
@@ -34,7 +34,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Spectre.Console.Cli" Version="0.48.0" />
+        <PackageReference Include="Serilog" Version="4.3.0" />
+        <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+        <PackageReference Include="Spectre.Console.Cli" Version="0.50.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     </ItemGroup>
 

--- a/AppleDev.Tool/Commands/AppStoreConnect/ProvisioningProfiles/ListProvisioningProfilesCommand.cs
+++ b/AppleDev.Tool/Commands/AppStoreConnect/ProvisioningProfiles/ListProvisioningProfilesCommand.cs
@@ -26,13 +26,16 @@ public class ListProvisioningProfilesCommand : AsyncCommand<ListProvisioningProf
 
 		foreach (var profile in profiles.Data)
 		{
+			var bundleIds = await appStoreConnect.GetRelatedBundleIdAsync(profile.Id).ConfigureAwait(false);
 			// Get the Bundle ID for the profile
-			var profileBundleId = profiles.IncludedBundleIds?.FirstOrDefault()?.Attributes;
+			var profileBundleId = bundleIds.Data.Attributes;
 
 			if (settings.BundleIds.Length > 0)
 			{
-				if (profileBundleId is not null && settings.BundleIds.Any(b => profileBundleId?.IdentifierMatches(b) ?? false))
+				if (settings.BundleIds.Any(b => profileBundleId?.IdentifierMatches(b) ?? false))
+				{
 					profileResults.Add(new ProvisioningProfile(profile.Attributes, profileBundleId));
+				}
 			}
 			else
 			{

--- a/AppleDev.Tool/Commands/CI/ProvisionCiCommand.cs
+++ b/AppleDev.Tool/Commands/CI/ProvisionCiCommand.cs
@@ -221,13 +221,13 @@ public class ProvisionCiCommand : AsyncCommand<ProvisionCiCommandSettings>
 
             foreach (var profile in profiles.Data)
             {
+                var bundleId = await appStoreConnect.GetRelatedBundleIdAsync(profile.Id).ConfigureAwait(false);
                 // Get the Bundle ID for the profile
-                var profileBundleId = profiles.IncludedBundleIds?.FirstOrDefault()?.Attributes;
+                var profileBundleId = bundleId.Data.Attributes;
 
                 if (settings.BundleIdentifiers.Length > 0)
                 {
-                    if (profileBundleId is not null &&
-                        settings.BundleIdentifiers.Any(b => profileBundleId?.IdentifierMatches(b) ?? false))
+                    if (settings.BundleIdentifiers.Any(b => profileBundleId?.IdentifierMatches(b) ?? false))
                         profileResults.Add(new ProvisioningProfile(profile.Attributes, profileBundleId));
                 }
                 else

--- a/AppleDev.Tool/Program.cs
+++ b/AppleDev.Tool/Program.cs
@@ -1,6 +1,13 @@
 ﻿using AppleDev.Tool.Commands;
+using Serilog;
 using Spectre.Console;
 using Spectre.Console.Cli;
+
+Log.Logger = new LoggerConfiguration()
+	.MinimumLevel.Information()
+	.Enrich.FromLogContext()
+	.WriteTo.Console()
+	.CreateLogger();
 
 var cts = new CancellationTokenSource();
 Console.CancelKeyPress += (sender, eventArgs) =>

--- a/AppleDev/AppleDev.csproj
+++ b/AppleDev/AppleDev.csproj
@@ -24,12 +24,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CliWrap" Version="3.6.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="CliWrap" Version="3.9.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="plist-cil" Version="2.2.0" />
-    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.1" />
+    <PackageReference Include="plist-cil" Version="2.3.1" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="9.0.8" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true' Or '$(TF_BUILD)' == 'true'">


### PR DESCRIPTION
Addresses an issue where the bundle ID associated with a provisioning profile was not being correctly retrieved.

The previous implementation was attempting to extract bundle ID information directly from the included bundle IDs, which was incorrect.

This change now retrieves the bundle ID using a dedicated API call, ensuring accurate identification of the bundle associated with each provisioning profile.
