### PR TITLE
Updates package versioning in CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,32 +13,33 @@ jobs:
       NUPKG_MAJOR: 0.999
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: |
-          8.0.x
-    - name: Pack
-      shell: pwsh
-      run: |
-        $VERSION="$env:NUPKG_MAJOR-ci$env:GITHUB_RUN_ID"
-        if ($env:GITHUB_EVENT_NAME -eq "release") {
-          $VERSION = $env:GITHUB_REF.Substring($env:GITHUB_REF.LastIndexOf('/') + 1)
-        }
-        echo "::set-output name=pkgverci::$VERSION"
-        echo "PACKAGE VERSION: $VERSION"
-        
-        New-Item -ItemType Directory -Force -Path .\artifacts
-        dotnet pack --output ./artifacts --configuration Release -p:PackageVersion=$VERSION ./AppleDev/AppleDev.csproj
-        dotnet pack --output ./artifacts --configuration Release -p:PackageVersion=$VERSION ./AppleDev.Tool/AppleDev.Tool.csproj
-        
-    - name: Artifacts
-      uses: actions/upload-artifact@v4.6.2
-      with:
-        name: NuGet
-        path: ./artifacts
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: |
+            8.0.x
+      - name: Pack
+        id: pack
+        shell: pwsh
+        run: |
+          $VERSION="$env:NUPKG_MAJOR-ci$env:GITHUB_RUN_ID"
+          if ($env:GITHUB_EVENT_NAME -eq "release") {
+            $VERSION = $env:GITHUB_REF.Substring($env:GITHUB_REF.LastIndexOf('/') + 1)
+          }
+          echo "pkgverci=$VERSION" >> $env:GITHUB_OUTPUT
+          echo "PACKAGE VERSION: $VERSION"
+          
+          New-Item -ItemType Directory -Force -Path .\artifacts
+          dotnet pack --output ./artifacts --configuration Release -p:PackageVersion=$VERSION ./AppleDev/AppleDev.csproj
+          dotnet pack --output ./artifacts --configuration Release -p:PackageVersion=$VERSION ./AppleDev.Tool/AppleDev.Tool.csproj
+
+      - name: Artifacts
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: NuGet
+          path: ./artifacts
 
   publish:
     name: Publish


### PR DESCRIPTION
Updates the CI workflow to set the package version as an output variable, allowing it to be used in subsequent steps. This change ensures correct package versioning during continuous integration builds.